### PR TITLE
install ast php extension to allow running static analysis tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get install -y \
     php7.0-zip \
     php7.0-pdo \
     php7.0-pdo-mysql \
-    php7.0-soap
+    php7.0-soap \
+    php-ast
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN npm install -g yarn m2-builder@1


### PR DESCRIPTION
We can take our coding standards further and prevent runtime errors on production by running static analysis tools such as **phpstan/phan** which will catch errors such as wrong number of arguments passed to functions, type-hinting classes which don't exists, calling private methods, etc... which otherwise will blow up in production and are easy to miss during code reviews.

This static analysis tools require the php **ast** extension to run, this PR installs that so that is available on Circle-CI so that projects can start using those tools to improve coding standards and prevent bugs on production.

**NOTE** Because the **ast** extension is only available from PHP7, the package is just called **php-ast** as opposed to **php7.0-ast**