### PR TITLE
We don't technically need to build 7.2 yet... :sob:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
         machine: true
         steps:
             - checkout
-            - run: ./build.sh 7.2
-            - run: ./publish.sh 7.2
+            - run: ./build.sh 7.1
+            - run: ./publish.sh 7.1
 
     build-5.6:
         machine: true
@@ -21,13 +21,6 @@ jobs:
             - checkout
             - run: ./build.sh 7.0
             - run: ./publish.sh 7.0
-
-    build-7.1:
-            machine: true
-            steps:
-                - checkout
-                - run: ./build.sh 7.1
-                - run: ./publish.sh 7.1
 
 workflows:
     version: 2
@@ -46,12 +39,6 @@ workflows:
                             - master
 
             - build-7.0:
-                filters:
-                    branches:
-                        only:
-                            - master
-
-            - build-7.1:
                 filters:
                     branches:
                         only:

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ HERE=$(dirname $0)
 
 PHPVER=${1}
 REPO=wearejh/ci-build-env
-SUPPORTED=(5.6 7.0 7.1 7.2)
+SUPPORTED=(5.6 7.0 7.1)
 
 if [ ${#PHPVER} -lt 1 ]; then
     echo "build.sh php-version"

--- a/publish.sh
+++ b/publish.sh
@@ -4,7 +4,7 @@ HERE=$(dirname $0)
 
 PHPVER=${1}
 REPO=wearejh/ci-build-env
-SUPPORTED=(5.6 7.0 7.1 7.2)
+SUPPORTED=(5.6 7.0 7.1)
 
 if [ ${#PHPVER} -lt 1 ]; then
     echo "build.sh php-version"


### PR DESCRIPTION
Fails cause mcrypt, there's me hoping we'd be able to stick with a single dockerfile. 

For now drop 7.2 and we can handle that when we're actually able to use it. 