### PR TITLE
configure jpeg directory when building gd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apk --update add \
     ruby \
     ruby-bundler
 
+RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/
+
 RUN docker-php-ext-install \
     gd \
     intl \


### PR DESCRIPTION
After doing this, we seem to have JPEG support!

```
[~/Code/ci-build-env]$ sudo docker run -i -t 5380bed9fa54 /bin/sh                                                                                                                                   *[build-jpeg] 
~/build # php -r 'print_r(gd_info());'
Array
(
    [GD Version] => bundled (2.1.0 compatible)
    [FreeType Support] => 
    [GIF Read Support] => 1
    [GIF Create Support] => 1
    [JPEG Support] => 1
    [PNG Support] => 1
    [WBMP Support] => 1
    [XPM Support] => 
    [XBM Support] => 1
    [WebP Support] => 
    [JIS-mapped Japanese Font Support] => 
)
~/build # 
```