### PR TITLE
Use nodejs 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ ENV PATH=/root/.composer/vendor/bin:$PATH
 
 RUN composer global require wearejh/m2-deploy-recipe:dev-master
 
-RUN apk add nodejs yarn
+COPY --from=node:8.16.0-alpine /usr/local/bin/node /usr/local/bin/node 
+
+RUN apk add yarn
 RUN yarn global add m2-builder@1
 
 RUN mkdir -p /root/build


### PR DESCRIPTION
Whilst working on a project with 7.1 the yarn install crapped out with a package requiring nodejs <9 ..

I'm not entirely sure if switching out for nodejs 8 is the right thing to do here, or if the packages need to be looked at on the project to resolve. 

Let me know what you think @shakyShane 