### PR TITLE
Add PHP 7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
         machine: true
         steps:
             - checkout
-            - run: ./build.sh 7.1
-            - run: ./publish.sh 7.1
+            - run: ./build.sh 7.2
+            - run: ./publish.sh 7.2
 
     build-5.6:
         machine: true
@@ -21,6 +21,13 @@ jobs:
             - checkout
             - run: ./build.sh 7.0
             - run: ./publish.sh 7.0
+
+    build-7.1:
+        machine: true
+        steps:
+            - checkout
+            - run: ./build.sh 7.1
+            - run: ./publish.sh 7.1
 
 workflows:
     version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{VERSION}}-cli-alpine
+FROM php:7.2-cli-alpine
 MAINTAINER JH <hello@wearejh.com>
 
 RUN apk --update add \
@@ -22,7 +22,8 @@ RUN apk --update add \
     libgcc \
     ruby \
     ruby-json \
-    ruby-bundler
+    ruby-bundler \
+    libsodium-dev
 
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/
 
@@ -30,7 +31,6 @@ RUN docker-php-ext-install \
     gd \
     intl \
     mbstring \
-    mcrypt \
     pdo_mysql \
     xsl \
     zip \
@@ -39,6 +39,16 @@ RUN docker-php-ext-install \
     mysqli \
     opcache \
     pcntl
+
+RUN [ $(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") -lt 72 ] \
+    && docker-php-ext-install \
+        mcrypt \
+    ; true
+
+RUN [ $(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") -ge 72 ] \
+    && docker-php-ext-install \
+        sodium \
+    ; true
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer 
 ENV PATH=/root/.composer/vendor/bin:$PATH

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ HERE=$(dirname $0)
 
 PHPVER=${1}
 REPO=wearejh/ci-build-env
-SUPPORTED=(5.6 7.0 7.1)
+SUPPORTED=(5.6 7.0 7.1 7.2)
 
 if [ ${#PHPVER} -lt 1 ]; then
     echo "build.sh php-version"


### PR DESCRIPTION
This adds PHP 7.2 support. The blocker on this previously was mcrypt and libsodium which I figured out when I was doing wf2 stuff. 

7.2 is now the default build in circle followed by 5.6, 7.0 and 7.1. 