### PR TITLE
lock npm repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ RUN apk --update add \
     ruby-bundler \
     libsodium-dev \
     nodejs \
-    npm \
     yarn
+
+RUN apk add npm --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main
 
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/
 


### PR DESCRIPTION
NPM is not in the repositories of `php:7.0-alpine` image. It uses alpine version v3.7.

We tell APK to use a newer repo when installing NPM.