### PR TITLE
install perl-utils package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apk --update add \
     nodejs \
     npm \
     yarn \
-    procps
+    procps \
+    perl-utils
 
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ --with-freetype-dir=/usr/include/
 RUN docker-php-ext-configure zip --with-libzip=/usr/include/


### PR DESCRIPTION
The CI-Tool requires shasum to work out the current git tree hash. 
shasum is part of the perl-utils package.