### PR TITLE
Add support for composer2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
             - checkout
             - run: ./build.sh 7.4
             - run: ./publish.sh 7.4
+            - checkout
+            - run: ./build.sh 7.4 2
+            - run: ./publish.sh 7.4 2
 
     build-7.3:
         machine: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:{{VERSION}}-cli-alpine
+FROM php:{{PHP_VERSION}}-cli-alpine
 MAINTAINER JH <hello@wearejh.com>
 
 RUN apk --update add \
@@ -68,7 +68,7 @@ RUN [ $(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") -ge 72 ] \
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ENV PATH=/root/.composer/vendor/bin:$PATH
 
-RUN composer selfupdate --1
+RUN composer selfupdate --{{COMPOSER_VERSION}}
 RUN composer global require wearejh/m2-deploy-recipe:dev-master
 RUN composer global config repositories.ci-tool vcs git@github.com:WeareJH/ci-tool.git
 

--- a/build.sh
+++ b/build.sh
@@ -3,24 +3,37 @@
 HERE=$(dirname $0)
 
 PHPVER=${1}
+#composer version default to 1
+[[ ${#2} -lt 1 ]] && COMPOSERVER=1 || COMPOSERVER=${2}
 REPO=wearejh/ci-build-env
 SUPPORTED=(7.1 7.2 7.3 7.4)
+COMPOSER_SUPPORTED=(1 2)
 
-if [ ${#PHPVER} -lt 1 ]; then
-    echo "build.sh php-version"
+#Check all parameters are present
+if [ ${#PHPVER} -lt 1 ] || [ ${#COMPOSERVER} -lt 1 ]; then
+    echo "build.sh php-version composer-version"
     exit
 fi
-
+#Check PHP version supplied is supported
 if [[ ! " ${SUPPORTED[@]} " =~ " ${PHPVER} " ]]; then
     echo "PHP version ${PHPVER} not supported"
     exit
 fi
+#Check Composer version supplied is supported
+if [[ ! " ${COMPOSER_SUPPORTED[@]} " =~ " ${COMPOSERVER} " ]]; then
+    echo "Composer version ${COMPOSERVER} not supported"
+    exit
+fi
 
-# Pull current build for comparison before punblish
-docker pull ${REPO}:${PHPVER}
-docker tag ${REPO}:${PHPVER} ${REPO}:${PHPVER}-current
+# Pull current build for comparison before publish
+[[ $COMPOSERVER -ge 2 ]] && COMP_SUFFIX="-comp2" || COMP_SUFFIX=""
+IMAGE_URI=${REPO}:${PHPVER}${COMP_SUFFIX}
+
+docker pull ${IMAGE_URI}
+docker tag ${IMAGE_URI} ${IMAGE_URI}-current
 
 # PHP 7.x share a common Dockerfile
 # Set the required version in the Dockerfile
-sed -i -e "s/{{VERSION}}/${PHPVER}/g" Dockerfile
-docker build --no-cache -f Dockerfile -t ${REPO}:${PHPVER} ${HERE}
+sed -i -e "s/{{PHP_VERSION}}/${PHPVER}/g" Dockerfile
+sed -i -e "s/{{COMPOSER_VERSION}}/${COMPOSERVER}/g" Dockerfile
+docker build --no-cache -f Dockerfile -t ${IMAGE_URI} ${HERE}

--- a/publish.sh
+++ b/publish.sh
@@ -3,24 +3,37 @@
 HERE=$(dirname $0)
 
 PHPVER=${1}
+#composer version default to 1
+[[ ${#2} -lt 1 ]] && COMPOSERVER=1 || COMPOSERVER=${2}
 REPO=wearejh/ci-build-env
 SUPPORTED=(7.1 7.2 7.3 7.4)
+COMPOSER_SUPPORTED=(1 2)
 IMAGEVER=$(date '+%Y%m%d%H%M')
 
-if [ ${#PHPVER} -lt 1 ]; then
-    echo "build.sh php-version"
+#Check all parameters are present
+if [ ${#PHPVER} -lt 1 ] || [ ${#COMPOSERVER} -lt 1 ]; then
+    echo "build.sh php-version composer-version"
     exit
 fi
-
+#Check PHP version supplied is supported
 if [[ ! " ${SUPPORTED[@]} " =~ " ${PHPVER} " ]]; then
     echo "PHP version ${PHPVER} not supported"
     exit
 fi
-
-docker tag $REPO:$PHPVER $REPO:$PHPVER-$IMAGEVER
+#Check Composer version supplied is supported
+if [[ ! " ${COMPOSER_SUPPORTED[@]} " =~ " ${COMPOSERVER} " ]]; then
+    echo "Composer version ${COMPOSERVER} not supported"
+    exit
+fi
+#construct docker image URI
+[[ $COMPOSERVER -ge 2 ]] && COMP_SUFFIX="-comp2" || COMP_SUFFIX=""
+IMAGE_URI=${REPO}:${PHPVER}${COMP_SUFFIX}
+#create a tag containing the current time suffix
+#so that it is possible to target a specific build
+docker tag $IMAGE_URI $IMAGE_URI-$IMAGEVER
 
 # Compare image to current before push
-LAYER_DIFF=$(diff <(docker inspect $REPO:$PHPVER | jq '.[0].RootFS.Layers') <(docker inspect $REPO:$PHPVER-current | jq '.[0].RootFS.Layers'))
+LAYER_DIFF=$(diff <(docker inspect $IMAGE_URI | jq '.[0].RootFS.Layers') <(docker inspect $IMAGE_URI-current | jq '.[0].RootFS.Layers'))
 
 if [ -z "${LAYER_DIFF}" ]; then
     echo "Looks like this is exactly the same as the current build... skipping publish"
@@ -28,5 +41,6 @@ if [ -z "${LAYER_DIFF}" ]; then
 fi
 
 docker login -u $DOCKER_USER -p $DOCKER_PASS
-docker push $REPO:$PHPVER
-docker push $REPO:$PHPVER-$IMAGEVER
+#Push both tags for this image, one generic and one tied to this specific timestamp.
+docker push $IMAGE_URI
+docker push $IMAGE_URI-$IMAGEVER


### PR DESCRIPTION
A couple of new images will be generated for PHP7.4: `7.4-comp2` and `7.4-comp2-xxx` where xxx is the current timestamp.
`build.sh` and `publish.sh` accept now two arguments, the PHP version and the Composer version. It's very easy now to build composer 2 images for all versions of PHP, however in order to not start building new images that we don't need I'm only configured CI to build composer 2 images for PHP7.4.