### PR TITLE
Update Dockerfile to include icu-data-full

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apk --update add \
     g++ \
     icu \
     icu-dev \
+    icu-data-full \
     libmcrypt-dev \
     libxslt-dev \
     libstdc++ \


### PR DESCRIPTION
See issue:

https://github.com/magento/magento2/issues/35655
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split